### PR TITLE
Fix of autoloading and usafe of Util class in reports

### DIFF
--- a/lib/Testify/testify.report.cli.php
+++ b/lib/Testify/testify.report.cli.php
@@ -1,5 +1,4 @@
 <?php
-require '../vendor/autoload.php';
 
 $result = $suiteResults['fail'] === 0 ? 'pass' : 'fail';
 

--- a/lib/Testify/testify.report.html.php
+++ b/lib/Testify/testify.report.html.php
@@ -1,6 +1,4 @@
-<?php
-require '../vendor/autoload.php';
-?><!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="utf-8" />
@@ -185,7 +183,7 @@ require '../vendor/autoload.php';
 
 				<div class="message <?php echo $result?>">
 					<span class="green">Far out! Everything passed!</span>
-					<span class="red">Bummer! You have failing tests! [pass <?php echo \Testify\Util\percent($suiteResults)?>%]</span>
+					<span class="red">Bummer! You have failing tests! [pass <?php echo \Testify\Util::percent($suiteResults)?>%]</span>
 				</div>
 
 				<?php


### PR DESCRIPTION
I removed redundant autoloading from the report files which should be handled by the test class or some kind of runner a developer creates.

The HTML report used a function that didn't existed and also results in an error.
