### PR TITLE
add functionality for creating custom reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+composer.lock

--- a/examples/example3.php
+++ b/examples/example3.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This is a minimal example of Testify using run() with a custom reporter
+ *
+ */
+
+require '../vendor/autoload.php';
+
+use Testify\Testify;
+
+$tf = new Testify("A basic test suite using run a custom reporter.");
+
+// Add a test case
+$tf->test("Just testing around", function($tf) {
+
+	$tf->assert(true, "Must pass !");
+	$tf->assertFalse(false);
+	$tf->assertEquals(1,'1');
+	$tf->assertSame(1,1);
+
+	$tf->assertInArray('a',array(1,2,3,4,5,'a'));
+	$tf->pass("Always pass");
+
+});
+
+$tf->test("I've got a bad feeling about this one", function($tf) {
+
+	$tf->assert(false);
+	$tf->assertFalse(true);
+	$tf->assertEquals(1,'-21');
+	$tf->assertSame(1,'1');
+
+	$tf->assertInArray('b',array(1,2,3,4,5,'a'));
+	$tf->fail();
+
+});
+
+$tf->test("This should work fine", function($tf) {
+
+    $tf->assert(true, "Must pass again!");
+	$tf->assertFalse(false);
+
+});
+
+$tf->run(function($title, $suiteResults, $cases) {
+    $tests = 0;
+    $passed = 0;
+    $errors = '';
+    
+    echo "<strong>{$title}</strong><br>";    
+    foreach($cases as $caseTitle => $case) {
+        $tests += 1;
+        if( !$case['fail'] ){
+            echo "<span style='color:#008800;'>{$caseTitle}</span><br>";
+            $passed += 1;
+        }else{
+            foreach ($case['tests'] as $test) {
+                if( $test['result'] == 'fail' ){
+                    $error = "<span style='color:#880000;'>{$caseTitle}</span><br>";
+                    echo $error;                    
+                    $errors .= "- $error<code style='color:#bb0000;'>&nbsp;[{$test['file']}][{$test['line']}] {$test['source']}</code><br>";
+                    continue 2;              
+                }                
+            }
+        }
+    }
+    
+    echo "------<br><span>$passed/$tests passed</span>";
+    if( $errors ){
+        echo '<br><br>The following test functions failed:<br>';
+        echo $errors;
+    }
+});

--- a/lib/Testify/Testify.php
+++ b/lib/Testify/Testify.php
@@ -31,6 +31,8 @@ class Testify {
     private $after = null;
     private $beforeEach = null;
     private $afterEach = null;
+    
+    private $customReporter = null;
 
     /**
      * As html report need google api(font), while not available in China, this is an option to surrend to gfw(great fire wall)
@@ -126,10 +128,13 @@ class Testify {
     /**
      * Run all the tests and before / after functions. Calls {@see report} to generate the HTML report page.
      *
+     * @param \function $customReporter An anonymous function for creating custom reports used in {@see report}
+     *
      * @return $this
      */
-    public function run()
+    public function run(\Closure $customReporter = null)
     {
+        $this->customReporter = $customReporter;
         $arr = array($this);
 
         if (is_callable($this->before)) {
@@ -310,7 +315,7 @@ class Testify {
     }
 
     /**
-     * Generates a pretty CLI or HTML5 report of the test suite status. Called implicitly by {@see run}.
+     * Generates a pretty CLI, HTML5 or custom report of the test suite status. Called implicitly by {@see run}.
      *
      * @return $this
      */
@@ -319,8 +324,10 @@ class Testify {
         $title = $this->suiteTitle;
         $suiteResults = $this->suiteResults;
         $cases = $this->stack;
-
-        if (php_sapi_name() === 'cli') {
+        
+        if (is_callable($this->customReporter)) {
+            call_user_func($this->customReporter, $title, $suiteResults, $cases );
+        } else if (php_sapi_name() === 'cli') {
             include dirname(__FILE__) . '/testify.report.cli.php';
         } else {
             include dirname(__FILE__) . '/testify.report.html.php';


### PR DESCRIPTION
Enable extending Testify with custom reporters, given directly as an argument to the run()function
